### PR TITLE
Реализация USART

### DIFF
--- a/src/act-photo.ewp
+++ b/src/act-photo.ewp
@@ -22,7 +22,7 @@
         <option>
           <name>Variant Memory</name>
           <version>0</version>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>ExePath</name>
@@ -145,29 +145,29 @@
         </option>
         <option>
           <name>RTConfigPath</name>
-          <state>$TOOLKIT_DIR$\LIB\DLIB\dlAVR-1t-ec_mul-n.h</state>
+          <state>$TOOLKIT_DIR$\LIB\DLIB\dlAVR-1s-ec_mul-n.h</state>
         </option>
         <option>
           <name>RTLibraryPath</name>
-          <state>$TOOLKIT_DIR$\LIB\DLIB\dlAVR-1t-ec_mul-n.r90</state>
+          <state>$TOOLKIT_DIR$\LIB\DLIB\dlAVR-1s-ec_mul-n.r90</state>
         </option>
         <option>
           <name>Input variant</name>
           <version>0</version>
-          <state>1</state>
+          <state>3</state>
         </option>
         <option>
           <name>Input description</name>
-          <state> No specifier n, no float or long long.</state>
+          <state> No specifier n, no float or long long, no scan set, no assignment suppressing.</state>
         </option>
         <option>
           <name>Output variant</name>
           <version>0</version>
-          <state>1</state>
+          <state>4</state>
         </option>
         <option>
           <name>Output description</name>
-          <state> No specifier a or A.</state>
+          <state> No specifier a or A, no specifier n, no float or long long, no flags.</state>
         </option>
         <option>
           <name>GRuntimeLibSelectSlave</name>
@@ -263,7 +263,7 @@
         </option>
         <option>
           <name>CCListCFile</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>CCListCMnemonics</name>
@@ -271,15 +271,15 @@
         </option>
         <option>
           <name>CCListCMessages</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>CCListAssFile</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>CCListAssSource</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>CCEnableRemarks</name>
@@ -324,16 +324,16 @@
         <option>
           <name>CCLockRegs</name>
           <version>0</version>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>CCOptSizeSpeed</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>CCOptimization</name>
           <version>1</version>
-          <state>2</state>
+          <state>1</state>
         </option>
         <option>
           <name>CCAllowList</name>
@@ -407,7 +407,7 @@
         </option>
         <option>
           <name>CCCompilerRuntimeInfo</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>newCCIncludePaths</name>
@@ -432,12 +432,12 @@
         </option>
         <option>
           <name>CCOptSizeSpeedSlave</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>CCOptimizationSlave</name>
           <version>1</version>
-          <state>2</state>
+          <state>1</state>
         </option>
         <option>
           <name>CCOutputFile</name>
@@ -737,7 +737,7 @@
         </option>
         <option>
           <name>XList</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>SegmentMap</name>
@@ -1964,6 +1964,9 @@
   </configuration>
   <file>
     <name>$PROJ_DIR$\main.cpp</name>
+  </file>
+  <file>
+    <name>$PROJ_DIR$\usart.h</name>
   </file>
 </project>
 

--- a/src/usart.h
+++ b/src/usart.h
@@ -20,10 +20,10 @@ byte obuf[OBUF_SIZE];
 __regvar __no_init
 volatile byte iobuf_state @ 15;
 
-volatile byte ibuf_head   = 0;
-volatile byte ibuf_tail   = 0;
-volatile byte obuf_head   = 0;
-volatile byte obuf_tail   = 0;
+__tiny volatile byte ibuf_head   = 0;
+__tiny volatile byte ibuf_tail   = 0;
+__tiny volatile byte obuf_head   = 0;
+__tiny volatile byte obuf_tail   = 0;
 
 /* Accessed by the user code; USART interrupts must be disabled manually */
 /*

--- a/src/usart.h
+++ b/src/usart.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <intrinsics.h>
+
 typedef unsigned char byte;
 
 // Requires IBUFSIZE and OBUFSIZE be defined

--- a/src/usart.h
+++ b/src/usart.h
@@ -149,7 +149,10 @@ __interrupt void usart_rxc_interrupt_handler()
 #pragma vector=USART_UDRE_vect
 __interrupt void usart_udre_interrupt_handler()
 {
-    oread(UDR);
+    /* Must read the data anyway
+       in order to suppress unnecessary interrupts */
+    byte udr = UDR;
+    oread(udr);
 }
 
 /* Disable interrupts (see ATmega8A datasheet) */

--- a/src/usart.h
+++ b/src/usart.h
@@ -156,7 +156,10 @@ __interrupt void usart_rxc_interrupt_handler()
         /* Allow nested interrupts */
         __enable_interrupt();
         
-        iwrite(UDR);
+        /* Must read the data anyway
+           in order to suppress unnecessary interrupts */
+        byte udr = UDR; /* Reads from UDR */
+        iwrite(udr); /* Reads from udr */
     )
 }
 
@@ -170,10 +173,7 @@ __interrupt void usart_udre_interrupt_handler()
     /* Allow nested interrupts */
     __enable_interrupt();
     
-    /* Must read the data anyway
-       in order to suppress unnecessary interrupts */
-    byte udr = UDR;
-    oread(udr);
+    oread(UDR); /* Writes to UDR */
 }
 
 /* Disable interrupts (see ATmega8A datasheet) */

--- a/src/usart.h
+++ b/src/usart.h
@@ -82,7 +82,7 @@ inline bool iread(byte &out)
 /*
  * Reads a byte from output buffer.
  *
- * Disables further USART interrupts on failure
+ * Keeps further USART interrupts disabled on failure.
  */
 #define oread(out) \
     if (iobuf_state & OBUF_NEMPTY) /* not empty */ \

--- a/src/usart.h
+++ b/src/usart.h
@@ -1,0 +1,168 @@
+#pragma once
+
+typedef unsigned char byte;
+
+// Requires IBUFSIZE and OBUFSIZE be defined
+// iobuf_state must be initialized
+
+byte ibuf[IBUF_SIZE];
+byte obuf[OBUF_SIZE];
+
+#define IBUF_NEMPTY 0x1
+#define IBUF_NFULL  0x2
+#define OBUF_NEMPTY 0x4
+#define OBUF_NFULL  0x8
+
+/*
+ * Since the variable to be accessed very often,
+ * it seems necessary to declare it as __regvar.
+ */
+__regvar __no_init
+volatile byte iobuf_state @ 15;
+
+volatile byte ibuf_head   = 0;
+volatile byte ibuf_tail   = 0;
+volatile byte obuf_head   = 0;
+volatile byte obuf_tail   = 0;
+
+/* Accessed by the user code; USART interrupts must be disabled manually */
+/*
+ * Reads a byte from input buffer.
+ *
+ * Returns true if byte was actually read, false otherwise
+ */
+inline bool iread(byte &out)
+{
+    if (iobuf_state & IBUF_NEMPTY) /* not empty */
+    {
+        byte h = ibuf_head;
+        out = ibuf[h++]; /* read byte */
+        if (h == IBUF_SIZE) h = 0;
+        if (h == ibuf_tail)
+        {
+            iobuf_state &= ~IBUF_NEMPTY /* mark empty */;
+        }
+        iobuf_state |= IBUF_NFULL /* mark not full */;
+        ibuf_head = h;
+        return true;
+    }
+    return false;
+}
+
+/* Accessed in the interruption code */
+/*
+ * Writes the byte to output buffer.
+ */
+#define iwrite(in) \
+    if (iobuf_state & IBUF_NFULL) /* not full */ \
+    { \
+        byte t = ibuf_tail; \
+        ibuf[t++] = in; /* write byte */ \
+        if (t == IBUF_SIZE) t = 0; \
+        if (t == ibuf_head) iobuf_state &= ~IBUF_NFULL /* make full */; \
+        iobuf_state |= IBUF_NEMPTY /* mark not empty */; \
+        ibuf_tail = t; \
+    }
+
+/* Accessed in the interruption code */
+/*
+ * Reads a byte from output buffer.
+ *
+ * Disables further USART interrupts on failure
+ */
+#define oread(out) \
+    if (iobuf_state & OBUF_NEMPTY) /* not empty */ \
+    { \
+        byte h = obuf_head; \
+        out = obuf[h++]; /* read byte */ \
+        if (h == OBUF_SIZE) h = 0; \
+        if (h == obuf_tail) iobuf_state &= ~OBUF_NEMPTY; /* mark empty */ \
+        iobuf_state |= OBUF_NFULL; /* mark not full */ \
+        obuf_head = h; \
+    } \
+    else \
+    { \
+        UCSRB &= ~(1 << UDRIE); /* Unset Data Reg. Empty interrupt */ \
+    }
+
+
+/* Accessed by the user code; USART interrupts must be disabled manually */
+/*
+ * Writes the byte to output buffer.
+ */
+inline void owrite(const byte &in)
+{
+    if (iobuf_state & OBUF_NFULL) /* not full */
+    {
+        byte t = obuf_tail;
+        obuf[t++] = in; /* write byte */
+        if (t == OBUF_SIZE) t = 0;
+        if (t == obuf_head) iobuf_state &= ~OBUF_NFULL /* make full */;
+        iobuf_state |= OBUF_NEMPTY; /* mark not empty */ \
+        obuf_tail = t;
+    }
+}
+
+inline byte isize()
+{
+    UCSRB &= ~(1 << RXCIE); /* Unset RX Complete interrupt */
+    byte result = 0;
+    if (iobuf_state & IBUF_NEMPTY) /* not empty */
+    {
+        /* Warnings are unreasonable for this block since
+           interrupts are disabled and no concurrent
+           access of variables occur. */
+        if (ibuf_head < ibuf_tail)
+        {
+            result = (ibuf_tail - ibuf_head);
+        }
+        else
+        {
+            result = IBUF_SIZE - (ibuf_head - ibuf_tail);
+        }
+    }
+    UCSRB |= (1 << RXCIE); /* Set RX Complete interrupt */
+    return result;
+}
+
+inline void transmit(const byte &in)
+{
+    UCSRB &= ~(1 << UDRIE); /* Unset Data Reg. Empty interrupt */
+    owrite(in);
+    UCSRB |= (1 << UDRIE); /* Set Data Reg. Empty interrupt */
+}
+
+inline bool receive(byte &out)
+{
+    UCSRB &= ~(1 << RXCIE); /* Unset RX Complete interrupt */
+    bool result = iread(out);
+    UCSRB |= (1 << RXCIE); /* Set RX Complete interrupt */
+    return result;
+}
+
+#pragma vector=USART_RXC_vect
+__interrupt void usart_rxc_interrupt_handler()
+{
+    iwrite(UDR);
+}
+
+#pragma vector=USART_UDRE_vect
+__interrupt void usart_udre_interrupt_handler()
+{
+    oread(UDR);
+}
+
+/* Disable interrupts (see ATmega8A datasheet) */
+inline __monitor void usart_init()
+{
+    const unsigned int ubrr = 1843200/16/9600-1;
+    /* Set baud rate */
+    UBRRH = (unsigned char) (ubrr>>8);
+    UBRRL = (unsigned char) ubrr;
+    /* Enable receiver and transmitter */
+    UCSRB = (1<<RXEN)|(1<<TXEN);
+    /* Set frame format: 8data, 1stop bit */
+    UCSRC = (1<<URSEL)|(3<<UCSZ0);
+     /* Set RX Complete interrupt */
+    UCSRB |= (1 << RXCIE);
+}


### PR DESCRIPTION
Полностью реализован `USART`-модуль на прерываниях и кольцевых буферах.

## Модель

Кольцевые буферы реализованы максимально ускоренным образом через статические массивы в глобальной области и макросы, задающие их размер. Переменные состояния (указатели на начало и конец буферов) хранятся в области `__tiny`. Статуст пустоты / полноты буфера лежит в регистре `R15`.

Работа с `USART` организована на прерываниях: `UDRE` (USART Data Register Empty) и `RXC` (USART Receive Complete). В момент перехода в прерывание запрещаются соответствующее USART-прерывание (`UDRE`, `RXC`), а остальные прерывания вновь разрешаются, позволяя осуществлять т.н. вложенные прерывания.

## Код

Перед началом использования `USART` на прием и передачу следует:

1. Инициализировать `USART` функцией `usart_init`.
2. Определить макросы `IBUF_SIZE` (Input Buffer Size) и `OBUF_SIZE` (Output Buffer Size).
3. Установить начальное значение переменной `iobuf_state` в `IBUF_NFULL | OBUF_NFULL`.

Все дальнейшие операции принимают и возвращают тип `byte`, определенный как `unsigned char`.

### Отправка

Для отправки байта `b` следует выполнить `owrite(b)`. Операция кладет байт в буфер вывода (`obuf`) и разрешает прерывание `UDRE`.

Как только внутренний `USART`-буфер передатчика станет доступен для записи, системой будет сгенерировано прерывание `UDRE`. В `USART`-буфер передатчика будет записан первый по очереди байт буфера вывода `obuf`. Пока выводной буфер `obuf` не опустеет, процесс будет продолжаться. Когда буфер `obuf` станет пустым, прерывание `UDRE` будет запрещено.

### Прием

Для приема байта `b` следует выполнить `iread(b)`. Операция читает байт из буфера ввода (`ibuf`). В случае успеха (буфер `ibuf` не пуст) возвращает `true`. В противном случае (буфер `ibuf` пуст) -- `false`.

Система генерирует прерывание `RXC` всякий раз при приеме очередного байта данных из `USART`-порта. В прерывании обработчик считывает данные и кладет их в буфер `ibuf`. В случае, если буфер заполнится, получаемые данные будут игнорироваться (выбрасываться) до тех пор, пока в буфере `ibuf` не станет доступной хотя бы одна ячейка.

Для обработки команд полезно знать текущий размер буфера. Его получение производится функцией `isize`.

### Пример получения команды, исполнения и отправки подтверждения

```c++
byte cmd;
bool wait_for_args = false;
while(true) // Message Loop
{
    //...
    if (wait_for_args)
    {
        switch(cmd)
        {
            case DO_SOMETHING_2ARGS:
                // wait for the arguments to receive
                if (isize() < 2) break;
                
                // all arguments received
                wait_for_args = false;
                
                // read arguments
                byte arg1, arg2;
                iread(arg1); iread(arg2);
                
                // execute command
                do_something(arg1, arg2);
                
                // respond
                owrite(DO_SOMETHING_2ARGS_DONE);

                break;
            case DO_SOMETHING_NOARG:
                // no arguments required
                wait_for_args = false;
                
                // execute command
                if (do_something())
                {
                    // respond with success
                    owrite(DO_SOMETHING_NOARG_SUCCESS);
                }
                else
                {
                    // respond with failure
                    owrite(DO_SOMETHING_NOARG_FAILURE);
                }

                break;
            //...
        }
    }
    else
    {
        // read next byte
        if (iread(cmd))
        {
            // check the received byte
            // if command -- wait for its arguments
            // else       -- skip
            wait_for_args = is_valid_command(cmd);
        }
    }
    //...
}
```