### PR TITLE
Улучшения в USART API

### DIFF
--- a/src/usart.h
+++ b/src/usart.h
@@ -67,7 +67,7 @@ inline bool iread(byte &out)
 /*
  * Writes the byte to output buffer.
  */
-#define iwrite(in) \
+#define _iwrite(in) \
     if (iobuf_state & IBUF_NFULL) /* not full */ \
     { \
         byte t = ibuf_tail; \
@@ -84,7 +84,7 @@ inline bool iread(byte &out)
  *
  * Keeps further USART interrupts disabled on failure.
  */
-#define oread(out) \
+#define _oread(out) \
     if (iobuf_state & OBUF_NEMPTY) /* not empty */ \
     { \
         byte h = obuf_head; \
@@ -165,7 +165,7 @@ __interrupt void usart_rxc_interrupt_handler()
         /* Must read the data anyway
            in order to suppress unnecessary interrupts */
         byte udr = UDR; /* Reads from UDR */
-        iwrite(udr); /* Reads from udr */
+        _iwrite(udr); /* Reads from udr */
     )
 }
 
@@ -179,7 +179,7 @@ __interrupt void usart_udre_interrupt_handler()
     /* Allow nested interrupts */
     __enable_interrupt();
     
-    oread(UDR); /* Writes to UDR */
+    _oread(UDR); /* Writes to UDR */
 }
 
 /* Disable interrupts (see ATmega8A datasheet) */

--- a/src/usart.h
+++ b/src/usart.h
@@ -100,8 +100,10 @@ inline bool iread(byte &out)
 /* Accessed by the user code; USART interrupts must be disabled manually */
 /*
  * Writes the byte to output buffer.
+ *
+ * Returns true if byte was actually written, false otherwise
  */
-inline void owrite(const byte &in)
+inline bool owrite(const byte &in)
 {
     if (iobuf_state & OBUF_NFULL) /* not full */
     {
@@ -109,9 +111,11 @@ inline void owrite(const byte &in)
         obuf[t++] = in; /* write byte */
         if (t == OBUF_SIZE) t = 0;
         if (t == obuf_head) iobuf_state &= ~OBUF_NFULL /* make full */;
-        iobuf_state |= OBUF_NEMPTY; /* mark not empty */ \
+        iobuf_state |= OBUF_NEMPTY; /* mark not empty */
         obuf_tail = t;
+        return true;
     }
+    return false;
 }
 
 inline byte isize()


### PR DESCRIPTION
Метод `owrite` теперь возвращает булевское значение (`true` в случае успеха, `false` в противном случае; см. #10).

Также непубличные макро-функции `iwrite` и `oread` были снабжены префиксом `_`.