### PR TITLE
Библиотека DLIB заменена на CLIB

### DIFF
--- a/src/include/common.h
+++ b/src/include/common.h
@@ -13,6 +13,11 @@
 
 typedef unsigned char byte;
 typedef signed char sbyte;
+#ifndef DLIB
+typedef byte bool;
+#define true 1
+#define false 0
+#endif
 
 
 inline byte ulog2 (unsigned int u)

--- a/src/include/usart.h
+++ b/src/include/usart.h
@@ -200,7 +200,7 @@ __interrupt void usart_udre_interrupt_handler()
 
 
 
-inline bool transmit(const byte &in)
+inline bool transmit(const byte in)
 {
     NO_DATA_REG_EMPTY(
         bool result = _owrite(&in, 1);
@@ -208,7 +208,7 @@ inline bool transmit(const byte &in)
     return result;
 }
 
-inline bool transmit(const byte *in, byte size)
+inline bool transmit_all(const byte *in, byte size)
 {
     NO_DATA_REG_EMPTY(
         bool result = _owrite(in, size);
@@ -216,15 +216,15 @@ inline bool transmit(const byte *in, byte size)
     return result;
 }
 
-inline bool receive(byte &out)
+inline bool receive(byte *out)
 {
     NO_RX_COMPLETE(
-        bool result = _iread(&out, 1);
+        bool result = _iread(out, 1);
     );
     return result;
 }
 
-inline bool receive(byte *out, byte size)
+inline bool receive_all(byte *out, byte size)
 {
     NO_RX_COMPLETE(
         bool result = _iread(out, size);

--- a/src/main/act-photo.ewp
+++ b/src/main/act-photo.ewp
@@ -133,23 +133,19 @@
         <option>
           <name>GRuntimeLibSelect</name>
           <version>0</version>
-          <state>1</state>
+          <state>4</state>
         </option>
         <option>
           <name>RTDescription</name>
-          <state>Use the normal configuration of the C/EC++</state>
-          <state>runtime library. No locale interface,</state>
-          <state>C locale, no file descriptor support,</state>
-          <state>no multibytes in printf and scanf, and</state>
-          <state>no hex floats in strtod.</state>
+          <state>Use the legacy C runtime library.</state>
         </option>
         <option>
           <name>RTConfigPath</name>
-          <state>$TOOLKIT_DIR$\LIB\DLIB\dlAVR-1s-ec_mul-n.h</state>
+          <state></state>
         </option>
         <option>
           <name>RTLibraryPath</name>
-          <state>$TOOLKIT_DIR$\LIB\DLIB\dlAVR-1s-ec_mul-n.r90</state>
+          <state>$TOOLKIT_DIR$\LIB\CLIB\cl1s-ec_mul.r90</state>
         </option>
         <option>
           <name>Input variant</name>
@@ -158,7 +154,7 @@
         </option>
         <option>
           <name>Input description</name>
-          <state> No specifier n, no float or long long, no scan set, no assignment suppressing.</state>
+          <state></state>
         </option>
         <option>
           <name>Output variant</name>
@@ -167,12 +163,12 @@
         </option>
         <option>
           <name>Output description</name>
-          <state> No specifier a or A, no specifier n, no float or long long, no flags.</state>
+          <state></state>
         </option>
         <option>
           <name>GRuntimeLibSelectSlave</name>
           <version>0</version>
-          <state>1</state>
+          <state>4</state>
         </option>
         <option>
           <name>GeneralEnableMisra</name>
@@ -420,7 +416,6 @@
         <option>
           <name>CCStdIncludePaths</name>
           <state>$TOOLKIT_DIR$\INC\</state>
-          <state>$TOOLKIT_DIR$\INC\DLIB\</state>
         </option>
         <option>
           <name>CCEepromSize</name>
@@ -903,7 +898,7 @@
         </option>
         <option>
           <name>xcProgramEntryLabelSelect</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>ListOutputFormat</name>

--- a/src/test/test.ewp
+++ b/src/test/test.ewp
@@ -133,19 +133,15 @@
         <option>
           <name>GRuntimeLibSelect</name>
           <version>0</version>
-          <state>1</state>
+          <state>4</state>
         </option>
         <option>
           <name>RTDescription</name>
-          <state>Use the normal configuration of the C/EC++</state>
-          <state>runtime library. No locale interface,</state>
-          <state>C locale, no file descriptor support,</state>
-          <state>no multibytes in printf and scanf, and</state>
-          <state>no hex floats in strtod.</state>
+          <state>Use the legacy C runtime library.</state>
         </option>
         <option>
           <name>RTConfigPath</name>
-          <state>$TOOLKIT_DIR$\LIB\DLIB\dlAVR-1s-ec_mul-n.h</state>
+          <state></state>
         </option>
         <option>
           <name>RTLibraryPath</name>
@@ -172,7 +168,7 @@
         <option>
           <name>GRuntimeLibSelectSlave</name>
           <version>0</version>
-          <state>1</state>
+          <state>4</state>
         </option>
         <option>
           <name>GeneralEnableMisra</name>


### PR DESCRIPTION
Исходники адаптированы к `CLIB` -- библиотеке чистого `C`.

Перегруженные функции `transmit`, `receive` и др. переименованы в `transmit`, `transmit_all`, `receive`, `receive_all` и т.д.

Определен тип `bool` как `typedef byte bool`. Определены макроконстанты `true = 1` и `false = 0`.

В настройках проектов выбрана библиотека `CLIB`.